### PR TITLE
Add support for Javascript-submitted forms

### DIFF
--- a/form_test.go
+++ b/form_test.go
@@ -1,0 +1,38 @@
+package vee
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormRendering(t *testing.T) {
+	type Demo struct {
+		Username string
+		Password string `vee:"type:password"`
+	}
+	noActionMethod, err := Render(&Demo{}, FormActionOption("script"))
+	if err != nil {
+		t.Errorf("Expected nil error, got %q", err)
+	}
+	methodIdx := strings.Index(noActionMethod, "method=\"POST\"")
+	if methodIdx != -1 {
+		t.Errorf("Expected no method attribute, got '%s'", noActionMethod[methodIdx:])
+	}
+	actionIdx := strings.Index(noActionMethod, "action=\"")
+	if actionIdx != -1 {
+		t.Errorf("Expected no action attribute, got '%s'", noActionMethod[actionIdx:])
+	}
+
+	actionMethod, err := Render(&Demo{}, FormActionOption("/register-user"))
+	if err != nil {
+		t.Errorf("Expected nil error, got %q", err)
+	}
+	methodIdx = strings.Index(actionMethod, "method=\"POST\"")
+	if methodIdx == -1 {
+		t.Errorf("Expected method=\"POST\", found nothing")
+	}
+	actionIdx = strings.Index(actionMethod, "action=\"/register-user\"")
+	if actionIdx == -1 {
+		t.Errorf("Expected action=\"/register-user\", found nothing")
+	}
+}

--- a/render.go
+++ b/render.go
@@ -10,13 +10,13 @@ import (
 
 // Render generates HTML form fields from a Go struct.
 // Accepts optional RenderOptions to customize form rendering.
-func Render(v any, opts ...*RenderOptions) (string, error) {
-	var options *RenderOptions
-	if len(opts) > 0 && opts[0] != nil {
-		options = opts[0]
-	} else {
-		options = &RenderOptions{}
-	}
+func Render(v any, opts ...RenderOption) (string, error) {
+	options := ConsolidateOptions(opts...)
+	// if len(opts) > 0 && opts[0] != nil {
+	// 	options = opts[0]
+	// } else {
+	// 	options = &RenderOption{}
+	// }
 	val := reflect.ValueOf(v)
 	typ := reflect.TypeOf(v)
 
@@ -80,13 +80,16 @@ func Render(v any, opts ...*RenderOptions) (string, error) {
 	if options.FormCSS != "" {
 		html.WriteString(fmt.Sprintf(` class="%s"`, escapeHTML(options.FormCSS)))
 	}
-	method := options.FormMethod
-	if method == "" {
-		method = "POST"
-	}
-	html.WriteString(fmt.Sprintf(` method="%s"`, method))
-	if options.FormAction != "" {
-		html.WriteString(fmt.Sprintf(` action="%s"`, escapeHTML(options.FormAction)))
+	// Skip method and action if we're going to submit the form via Javascript
+	if options.FormAction != "script" {
+		method := options.FormMethod
+		if method == "" {
+			method = "POST"
+		}
+		html.WriteString(fmt.Sprintf(` method="%s"`, method))
+		if options.FormAction != "" {
+			html.WriteString(fmt.Sprintf(` action="%s"`, escapeHTML(options.FormAction)))
+		}
 	}
 	html.WriteString(">\n")
 

--- a/types.go
+++ b/types.go
@@ -1,7 +1,7 @@
 package vee
 
-// RenderOptions configures form rendering behavior.
-type RenderOptions struct {
+// RenderOption configures form rendering behavior.
+type RenderOption struct {
 	// DefaultInputCSS sets default CSS classes for all input elements
 	DefaultInputCSS string
 
@@ -16,4 +16,68 @@ type RenderOptions struct {
 
 	// FormAction sets the action URL for the form
 	FormAction string
+}
+
+func InputCSSOption(css string) RenderOption {
+	return RenderOption{
+		DefaultInputCSS: css,
+	}
+}
+
+func FormIDOption(id string) RenderOption {
+	return RenderOption{
+		FormID: id,
+	}
+}
+
+func FormCSSOption(css string) RenderOption {
+	return RenderOption{
+		FormCSS: css,
+	}
+}
+
+func FormMethodOption(method string) RenderOption {
+	return RenderOption{
+		FormMethod: method,
+	}
+}
+
+func FormActionOption(action string) RenderOption {
+	return RenderOption{
+		FormAction: action,
+	}
+}
+
+func (option RenderOption) IsEqual(other RenderOption) bool {
+	return option.DefaultInputCSS == other.DefaultInputCSS &&
+		option.FormAction == other.FormAction &&
+		option.FormCSS == other.FormCSS &&
+		option.FormID == other.FormID &&
+		option.FormMethod == other.FormMethod
+}
+
+func (option *RenderOption) apply(other RenderOption) {
+	if other.DefaultInputCSS != "" {
+		option.DefaultInputCSS = other.DefaultInputCSS
+	}
+	if other.FormID != "" {
+		option.FormID = other.FormID
+	}
+	if other.FormCSS != "" {
+		option.FormCSS = other.FormCSS
+	}
+	if other.FormMethod != "" {
+		option.FormMethod = other.FormMethod
+	}
+	if other.FormAction != "" {
+		option.FormAction = other.FormAction
+	}
+}
+
+func ConsolidateOptions(opts ...RenderOption) *RenderOption {
+	target := &RenderOption{}
+	for _, opt := range opts {
+		target.apply(opt)
+	}
+	return target
 }


### PR DESCRIPTION
vee now supports forms submitted solely via client-side Javascript by frameworks such as Datastar. Calling `vee.Render` with a `RenderOption` setting the form action to `script` will cause vee to suppress emitting both method and action attributes when it renders the form.

Given a struct such as

```
type UserProfile struct {
    FirstName string
    LastName string
}
```

the following code will render a form ready for client-side submission

```
profile := UserProfile {
    FirstName: "Johnathan",
    LastName: "Doo",
}

vee.Render(&profile, vee.FormActionOption("script"))
```